### PR TITLE
Simplify board variables as matrix and squares

### DIFF
--- a/src/board/board.lua
+++ b/src/board/board.lua
@@ -15,8 +15,8 @@ function Board:new(width, height)
     local board = {
         width = width,
         height = height,
-        boardTetrominosMatrix = Matrix:new(width, height),
-        boardTetrominoSquares = {},
+        matrix = Matrix:new(width, height),
+        squares = {},
         holdable = true,
         heldTetromino = nil,
         gravityFrameCounter = FrameCounter:new(1/settings.gravitySpeed),
@@ -33,7 +33,7 @@ function Board:new(width, height)
 end
 
 function Board:getGhostTetromino()
-    self:updateMatrices()
+    self:updateMatrix()
     ghost = Tetromino:new(self.currentTetromino.id,
         self.currentTetromino.origin, colors.ASH)
     for i = 1, self.currentTetromino.rotationState.value do
@@ -42,7 +42,7 @@ function Board:getGhostTetromino()
     for i = 0, self.height do
         ghost:offset(0, -1)
         for _, square in pairs(ghost.squares) do
-            if square.y < 0 or self.boardTetrominosMatrix[square.x][square.y] == 1 then
+            if square.y < 0 or self.matrix[square.x][square.y] == 1 then
                 ghost:offset(0, 1)
                 break
             end
@@ -52,7 +52,7 @@ function Board:getGhostTetromino()
 end
 
 function Board:cycleNextTetromino()
-    self:updateMatrices()
+    self:updateMatrix()
     self.currentTetromino = self.nextTetromino
     self:checkOverlappingSpawn()
     self.ghostTetromino = self:getGhostTetromino()
@@ -61,7 +61,7 @@ end
 
 function Board:checkOverlappingSpawn()
     for _, square in pairs(self.currentTetromino.squares) do
-        if self.boardTetrominosMatrix:isFilled(square.x, square.y) then
+        if self.matrix:isFilled(square.x, square.y) then
             self.currentTetromino:offset(0, 1)
             self:checkGameOver()
         end
@@ -77,10 +77,10 @@ function Board:checkGameOver()
     end
 end
 
-function Board:updateMatrices()
-    self.boardTetrominosMatrix:clear()
-    for _, square in pairs(self.boardTetrominoSquares) do
-        self.boardTetrominosMatrix:fill(square.x, square.y)
+function Board:updateMatrix()
+    self.matrix:clear()
+    for _, square in pairs(self.squares) do
+        self.matrix:fill(square.x, square.y)
     end
 end
 
@@ -121,7 +121,7 @@ function Board:renderBackground()
 end
 
 function Board:render()
-    self:updateMatrices()
+    self:updateMatrix()
 
     -- Render the background
     self:renderBackground()
@@ -130,7 +130,7 @@ function Board:render()
     self.ghostTetromino:render()
 
     -- Render pieces except current one
-    for _, square in pairs(self.boardTetrominoSquares) do
+    for _, square in pairs(self.squares) do
         square:render()
     end
 
@@ -148,24 +148,24 @@ function Board:getTetrominoSquareIndex(squares, x, y)
 end
 
 function Board:clearLines(indices)
-    boardTetrominoSquaresCopy = utils.shallowcopy(self.boardTetrominoSquares)
+    squaresCopy = utils.shallowcopy(self.squares)
     for _, index in pairs(indices) do
-        for _, square in pairs(self.boardTetrominoSquares) do
+        for _, square in pairs(self.squares) do
             if square.y == index then
-                squareToRemove = self:getTetrominoSquareIndex(boardTetrominoSquaresCopy,
+                squareToRemove = self:getTetrominoSquareIndex(squaresCopy,
                                                               square.x, square.y)
                 if squareToRemove ~= nil then
-                    table.remove(boardTetrominoSquaresCopy, squareToRemove)
+                    table.remove(squaresCopy, squareToRemove)
                 end
             end
         end
     end
-    self.boardTetrominoSquares = utils.shallowcopy(boardTetrominoSquaresCopy)
+    self.squares = utils.shallowcopy(squaresCopy)
 end
 
 function Board:dropLines(indices)
     for linesDropped, index in pairs(indices) do
-        for key, square in pairs(self.boardTetrominoSquares) do
+        for key, square in pairs(self.squares) do
             if square.y > index - linesDropped then
                 square.y = square.y - 1
             end
@@ -176,7 +176,7 @@ end
 
 function Board:obstacleBelow()
     for _, square in pairs(self.currentTetromino.squares) do
-        if square.y <= 0 or self.boardTetrominosMatrix:isFilled(square.x, square.y - 1) then
+        if square.y <= 0 or self.matrix:isFilled(square.x, square.y - 1) then
             return true
         end
     end

--- a/src/movement/movement.lua
+++ b/src/movement/movement.lua
@@ -12,7 +12,7 @@ end
 function Movement:moveLeft()
     moveable = true
     for _, square in pairs(self.board.currentTetromino.squares) do
-        if square.x <= 0 or self.board.boardTetrominosMatrix[square.x - 1][square.y] ~= 0 then
+        if square.x <= 0 or self.board.matrix[square.x - 1][square.y] ~= 0 then
             moveable = false
             break
         end
@@ -26,7 +26,7 @@ end
 function Movement:moveRight()
     moveable = true
     for _, square in pairs(self.board.currentTetromino.squares) do
-        if square.x + 1 >= self.board.width or self.board.boardTetrominosMatrix[square.x + 1][square.y] ~= 0 then
+        if square.x + 1 >= self.board.width or self.board.matrix[square.x + 1][square.y] ~= 0 then
             moveable = false
             break
         end
@@ -40,7 +40,7 @@ end
 function Movement:moveDown()
     moveable = true
     for _, square in pairs(self.board.currentTetromino.squares) do
-        if square.y <= 0 or self.board.boardTetrominosMatrix[square.x][square.y - 1] ~= 0 then
+        if square.y <= 0 or self.board.matrix[square.x][square.y - 1] ~= 0 then
             moveable = false
             break
         end
@@ -54,7 +54,7 @@ end
 function Movement:moveUp()
     moveable = true
     for _, square in pairs(self.board.currentTetromino.squares) do
-        if square.y < self.board.height or self.board.boardTetrominosMatrix[square.x][square.y + 1] ~= 0 then
+        if square.y < self.board.height or self.board.matrix[square.x][square.y + 1] ~= 0 then
             moveable = false
             break
         end
@@ -69,7 +69,7 @@ function Movement:hardDrop()
     for i = 0, self.board.height, 1 do
         self.board.currentTetromino:offset(0, -1)
         for _, square in pairs(self.board.currentTetromino.squares) do
-            if square.y < 0 or self.board.boardTetrominosMatrix[square.x][square.y] == 1 then
+            if square.y < 0 or self.board.matrix[square.x][square.y] == 1 then
                 self.board.currentTetromino:offset(0, 1)
                 break
             end
@@ -77,13 +77,13 @@ function Movement:hardDrop()
     end
 
     for _, square in pairs(self.board.currentTetromino.squares) do
-        table.insert(self.board.boardTetrominoSquares, square)
+        table.insert(self.board.squares, square)
     end
 
     self.board:cycleNextTetromino()
     self.board.holdable = true
 
-    local filledIndices = self.board.boardTetrominosMatrix:getFilledIndices()
+    local filledIndices = self.board.matrix:getFilledIndices()
     self.board:clearLines(filledIndices)
     self.board:dropLines(filledIndices)
 
@@ -122,7 +122,7 @@ function Movement:wallKickTestPass(xOffset, yOffset)
     for _, square in pairs(self.board.currentTetromino.squares) do
         if square.x < 0 or square.x >= self.board.width or
            square.y < 0 or square.y >= self.board.height or
-           self.board.boardTetrominosMatrix:isFilled(square.x, square.y) then
+           self.board.matrix:isFilled(square.x, square.y) then
             self.board.currentTetromino:offset(-xOffset, -yOffset)
             return false
         end


### PR DESCRIPTION
Feel like the old names worked better in python, but now we only keep track of 1 matrix in lua so no need for the long name.
I think the same goes for squares - externally the variables is accessed as `board.squares` which is enough information imo. lmk what you think